### PR TITLE
Update ampersand-sync-localforage.js

### DIFF
--- a/lib/ampersand-sync-localforage.js
+++ b/lib/ampersand-sync-localforage.js
@@ -124,11 +124,8 @@ module.exports = function(name) {
     // If `this` is a collection it means
     // `collection.fetch` has been called.
     if (this.isCollection) {
-      // If there's no localforageKey for this collection, create
-      // it.
-      if (!this.sync.localforageKey) {
-        this.sync.localforageKey = name;
-      }
+      // Create a localforageKey
+      this.sync.localforageKey = name;
     } else { // `this` is a model if not a collection.
       // Generate an id if one is not set yet.
       if (!model.getId()) {


### PR DESCRIPTION
The previous behaviour was causing the first model in a collection to be overwritten every time the create method was called because it was using the previous model's localforageKey.
